### PR TITLE
Stage 7: CLI Polish + Config Diffing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,118 @@
+# olytrain
+
+Shared training infrastructure for olypro projects. Integrates MLflow experiment tracking, FiftyOne dataset inspection, checkpoint management, and evaluation tooling.
+
+## Installation
+
+```bash
+pip install -e .
+
+# With optional FiftyOne support:
+pip install -e ".[fiftyone]"
+
+# Development:
+pip install -e ".[dev]"
+```
+
+## Quick Start
+
+### Launch MLflow Dashboard
+
+```bash
+olytrain dashboard
+olytrain dashboard --host 0.0.0.0 --port 8080
+```
+
+### Training Callbacks (PyTorch)
+
+Add MLflow logging to movenet training with ~5 lines:
+
+```python
+try:
+    from olytrain.integrations.mlflow_task import MLflowTaskCallback
+    callback = MLflowTaskCallback(config=training_config, run_name="experiment-1")
+except ImportError:
+    callback = None
+
+# In training loop:
+if callback:
+    callback.on_train_start()
+    # ... on_batch_end(step, {"loss": loss}) ...
+    # ... on_epoch_end(epoch, {"val/acc": acc}) ...
+    callback.on_train_end()
+```
+
+For RTMPose training:
+
+```python
+from olytrain.integrations.mlflow_rtmpose import MLflowRTMPoseCallback
+callback = MLflowRTMPoseCallback(config=config)
+```
+
+### Ingest TensorBoard Events (TF-Vision)
+
+```bash
+olytrain runs ingest /path/to/tb/events --experiment vision --run-name "efficientdet-d1"
+olytrain runs ingest /path/to/tb/events --config training_config.yaml
+```
+
+### Browse & Compare Runs
+
+```bash
+olytrain runs list --experiment movenet --sort val/acc
+olytrain runs compare <run_id_1> <run_id_2>
+```
+
+### Dataset Inspection
+
+```bash
+# View stats (no FiftyOne needed):
+olytrain dataset stats annotations.json
+
+# Visual inspection (requires fiftyone):
+olytrain dataset inspect annotations.json images/ --type keypoints
+olytrain dataset inspect annotations.json images/ --type detection
+```
+
+### Checkpoint Management
+
+```bash
+olytrain checkpoint list
+olytrain checkpoint list --project movenet
+olytrain checkpoint prune movenet --keep 5
+olytrain checkpoint prune movenet --keep 3 --execute
+olytrain checkpoint sync /local/path remote-host /remote/path
+olytrain checkpoint sync /local/path remote-host /remote/path --download
+```
+
+### Config Diffing
+
+```bash
+olytrain config show config.yaml
+olytrain config diff config_v1.yaml config_v2.yaml
+```
+
+### Evaluation
+
+```bash
+olytrain eval movenet checkpoint.pth --output results/
+olytrain eval vision checkpoint.h5 --config config.yaml --output results/
+```
+
+## Architecture
+
+- **Composition over modification** — Callbacks are standalone objects, training scripts need ~5 lines added
+- **SQLite backend** — Zero-setup MLflow with local SQLite database
+- **Optional FiftyOne** — Dataset inspection is opt-in (`pip install olytrain[fiftyone]`)
+- **DDP-safe** — Callbacks only log from rank 0
+
+## Project Structure
+
+```
+src/olytrain/
+├── cli/               # Click-based CLI commands
+├── integrations/      # MLflow callbacks, TB parser, FiftyOne loaders
+├── checkpoint/        # Checkpoint discovery, pruning, sync
+├── eval/              # Evaluation visualizations (pose + detection)
+└── config.py          # Shared constants and paths
+```

--- a/src/olytrain/cli/config.py
+++ b/src/olytrain/cli/config.py
@@ -1,6 +1,38 @@
 """Config commands — diff and show training configs."""
 
+from __future__ import annotations
+
+from pathlib import Path
+
 import click
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+
+def _load_config(path: str) -> dict:
+    """Load a config file (YAML or Python dict repr)."""
+    text = Path(path).read_text()
+    try:
+        return yaml.safe_load(text) or {}
+    except yaml.YAMLError:
+        pass
+    # Fall back to Python literal eval for dict-style configs
+    import ast
+
+    return dict(ast.literal_eval(text))
+
+
+def _flatten(d: dict, prefix: str = "") -> dict[str, str]:
+    """Flatten a nested dict into dot-separated keys."""
+    items: dict[str, str] = {}
+    for k, v in d.items():
+        key = f"{prefix}{k}" if not prefix else f"{prefix}.{k}"
+        if isinstance(v, dict):
+            items.update(_flatten(v, key))
+        else:
+            items[key] = str(v)
+    return items
 
 
 @click.group()
@@ -9,12 +41,50 @@ def config() -> None:
 
 
 @config.command()
-def diff() -> None:
-    """Diff two training configurations."""
-    click.echo("Not yet implemented")
+@click.argument("config1", type=click.Path(exists=True))
+@click.argument("config2", type=click.Path(exists=True))
+def diff(config1: str, config2: str) -> None:
+    """Diff two training configurations side-by-side."""
+    c1 = _flatten(_load_config(config1))
+    c2 = _flatten(_load_config(config2))
+    all_keys = sorted(set(c1) | set(c2))
+
+    console = Console()
+    table = Table(title="Config Diff")
+    table.add_column("Key")
+    table.add_column(Path(config1).name, style="cyan")
+    table.add_column(Path(config2).name, style="magenta")
+    table.add_column("Status")
+
+    for key in all_keys:
+        v1 = c1.get(key, "[dim]<missing>[/dim]")
+        v2 = c2.get(key, "[dim]<missing>[/dim]")
+        if key not in c1:
+            status = "[green]+ added[/green]"
+        elif key not in c2:
+            status = "[red]- removed[/red]"
+        elif v1 != v2:
+            status = "[yellow]~ changed[/yellow]"
+        else:
+            status = "="
+        table.add_row(key, v1, v2, status)
+
+    console.print(table)
 
 
 @config.command()
-def show() -> None:
+@click.argument("config_path", type=click.Path(exists=True))
+def show(config_path: str) -> None:
     """Pretty-print a training configuration."""
-    click.echo("Not yet implemented")
+    data = _load_config(config_path)
+    flat = _flatten(data)
+
+    console = Console()
+    table = Table(title=f"Config: {Path(config_path).name}")
+    table.add_column("Key")
+    table.add_column("Value")
+
+    for key in sorted(flat):
+        table.add_row(key, flat[key])
+
+    console.print(table)

--- a/src/olytrain/cli/runs.py
+++ b/src/olytrain/cli/runs.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import click
+from rich.console import Console
+from rich.table import Table
 
 
 @click.group()
@@ -11,21 +13,140 @@ def runs() -> None:
 
 
 @runs.command("list")
-def list_runs() -> None:
+@click.option("--experiment", default=None, help="Filter by experiment name.")
+@click.option("--sort", "sort_by", default=None, help="Sort by metric name.")
+@click.option("--limit", default=20, type=int, help="Max runs to show.")
+def list_runs(experiment: str | None, sort_by: str | None, limit: int) -> None:
     """List training runs."""
-    click.echo("Not yet implemented")
+    import mlflow
+
+    from olytrain.integrations.mlflow_setup import ensure_mlflow
+
+    ensure_mlflow()
+
+    if experiment:
+        exp = mlflow.get_experiment_by_name(experiment)
+        if not exp:
+            click.echo(f"Experiment '{experiment}' not found.")
+            return
+        exp_ids = [exp.experiment_id]
+    else:
+        exp_ids = [
+            e.experiment_id
+            for e in mlflow.search_experiments()
+            if e.name != "Default"
+        ]
+
+    if not exp_ids:
+        click.echo("No experiments found.")
+        return
+
+    order = [f"metrics.{sort_by} DESC"] if sort_by else ["start_time DESC"]
+    runs_df = mlflow.search_runs(
+        experiment_ids=exp_ids, order_by=order, max_results=limit,
+        output_format="pandas",
+    )
+
+    if runs_df.empty:  # type: ignore[union-attr]
+        click.echo("No runs found.")
+        return
+
+    console = Console()
+    table = Table(title="Training Runs")
+    table.add_column("Run ID", style="dim")
+    table.add_column("Name")
+    table.add_column("Experiment")
+    table.add_column("Status")
+    table.add_column("Start Time")
+
+    # Add metric columns dynamically
+    metric_cols = [c for c in runs_df.columns if c.startswith("metrics.")][:5]  # type: ignore[union-attr]
+    for col in metric_cols:
+        table.add_column(col.replace("metrics.", ""), justify="right")
+
+    for _, row in runs_df.iterrows():  # type: ignore[union-attr]
+        values = [
+            row.get("run_id", "")[:8],
+            row.get("tags.mlflow.runName", ""),
+            row.get("experiment_id", ""),
+            row.get("status", ""),
+            str(row.get("start_time", ""))[:19],
+        ]
+        for col in metric_cols:
+            val = row.get(col)
+            values.append(f"{val:.4f}" if val is not None and val == val else "")
+        table.add_row(*values)
+
+    console.print(table)
 
 
 @runs.command()
-def compare() -> None:
+@click.argument("run1")
+@click.argument("run2")
+def compare(run1: str, run2: str) -> None:
     """Compare two training runs side-by-side."""
-    click.echo("Not yet implemented")
+    import mlflow
+
+    from olytrain.integrations.mlflow_setup import ensure_mlflow
+
+    ensure_mlflow()
+    client = mlflow.tracking.MlflowClient()
+
+    try:
+        r1 = client.get_run(run1)
+        r2 = client.get_run(run2)
+    except mlflow.exceptions.MlflowException as e:
+        click.echo(f"Error: {e}")
+        return
+
+    console = Console()
+
+    # Compare params
+    p1, p2 = r1.data.params, r2.data.params
+    all_params = sorted(set(p1) | set(p2))
+    if all_params:
+        ptable = Table(title="Parameters")
+        ptable.add_column("Param")
+        ptable.add_column(f"Run {run1[:8]}", style="cyan")
+        ptable.add_column(f"Run {run2[:8]}", style="magenta")
+        ptable.add_column("Match")
+        for p in all_params:
+            v1 = p1.get(p, "-")
+            v2 = p2.get(p, "-")
+            match = "[green]=[/green]" if v1 == v2 else "[yellow]!=[/yellow]"
+            ptable.add_row(p, v1, v2, match)
+        console.print(ptable)
+
+    # Compare metrics
+    m1, m2 = r1.data.metrics, r2.data.metrics
+    all_metrics = sorted(set(m1) | set(m2))
+    if all_metrics:
+        mtable = Table(title="Metrics")
+        mtable.add_column("Metric")
+        mtable.add_column(f"Run {run1[:8]}", justify="right", style="cyan")
+        mtable.add_column(f"Run {run2[:8]}", justify="right", style="magenta")
+        mtable.add_column("Delta", justify="right")
+        for m in all_metrics:
+            v1 = m1.get(m)
+            v2 = m2.get(m)
+            s1 = f"{v1:.4f}" if v1 is not None else "-"
+            s2 = f"{v2:.4f}" if v2 is not None else "-"
+            delta = ""
+            if v1 is not None and v2 is not None:
+                d = v2 - v1
+                color = "green" if d > 0 else "red" if d < 0 else "white"
+                delta = f"[{color}]{d:+.4f}[/{color}]"
+            mtable.add_row(m, s1, s2, delta)
+        console.print(mtable)
 
 
 @runs.command()
 @click.argument("tb_dir", type=click.Path(exists=True))
 @click.option(
-    "--config", "config_path", type=click.Path(exists=True), help="Training config YAML to log."
+    "--config",
+    "config_path",
+    type=click.Path(exists=True),
+    help="Training config YAML to log.",
 )
 @click.option("--experiment", default="vision", help="MLflow experiment name.")
 @click.option("--run-name", default=None, help="MLflow run name.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,17 +27,20 @@ def test_dashboard_help():
     assert "--port" in result.output
 
 
-def test_runs_list():
+def test_runs_list_help():
     runner = CliRunner()
-    result = runner.invoke(cli, ["runs", "list"])
+    result = runner.invoke(cli, ["runs", "list", "--help"])
     assert result.exit_code == 0
-    assert "Not yet implemented" in result.output
+    assert "--experiment" in result.output
+    assert "--sort" in result.output
 
 
-def test_runs_compare():
+def test_runs_compare_help():
     runner = CliRunner()
-    result = runner.invoke(cli, ["runs", "compare"])
+    result = runner.invoke(cli, ["runs", "compare", "--help"])
     assert result.exit_code == 0
+    assert "RUN1" in result.output
+    assert "RUN2" in result.output
 
 
 def test_dataset_inspect():
@@ -74,28 +77,33 @@ def test_checkpoint_sync():
     assert "Sync checkpoints" in result.output
 
 
-def test_eval_movenet():
+def test_eval_movenet_help():
     runner = CliRunner()
-    result = runner.invoke(cli, ["eval", "movenet"])
+    result = runner.invoke(cli, ["eval", "movenet", "--help"])
     assert result.exit_code == 0
+    assert "CHECKPOINT" in result.output
 
 
-def test_eval_vision():
+def test_eval_vision_help():
     runner = CliRunner()
-    result = runner.invoke(cli, ["eval", "vision"])
+    result = runner.invoke(cli, ["eval", "vision", "--help"])
     assert result.exit_code == 0
+    assert "CHECKPOINT" in result.output
 
 
-def test_config_diff():
+def test_config_diff_help():
     runner = CliRunner()
-    result = runner.invoke(cli, ["config", "diff"])
+    result = runner.invoke(cli, ["config", "diff", "--help"])
     assert result.exit_code == 0
+    assert "CONFIG1" in result.output
+    assert "CONFIG2" in result.output
 
 
-def test_config_show():
+def test_config_show_help():
     runner = CliRunner()
-    result = runner.invoke(cli, ["config", "show"])
+    result = runner.invoke(cli, ["config", "show", "--help"])
     assert result.exit_code == 0
+    assert "CONFIG_PATH" in result.output
 
 
 def test_all_subcommands_visible_in_help():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,58 @@
+"""Tests for config diff and show commands."""
+
+import tempfile
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+from olytrain.cli import cli
+from olytrain.cli.config import _flatten, _load_config
+
+
+def test_flatten_simple():
+    assert _flatten({"a": 1, "b": 2}) == {"a": "1", "b": "2"}
+
+
+def test_flatten_nested():
+    result = _flatten({"model": {"backbone": "resnet", "layers": 50}})
+    assert result == {"model.backbone": "resnet", "model.layers": "50"}
+
+
+def test_flatten_deeply_nested():
+    result = _flatten({"a": {"b": {"c": "deep"}}})
+    assert result == {"a.b.c": "deep"}
+
+
+def test_load_config_yaml():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.dump({"lr": 0.001, "model": {"backbone": "resnet"}}, f)
+        f.flush()
+        config = _load_config(f.name)
+    assert config["lr"] == 0.001
+    assert config["model"]["backbone"] == "resnet"
+
+
+def test_config_diff_cli():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c1 = Path(tmpdir) / "config1.yaml"
+        c2 = Path(tmpdir) / "config2.yaml"
+        c1.write_text(yaml.dump({"lr": 0.001, "epochs": 100, "model": "resnet"}))
+        c2.write_text(yaml.dump({"lr": 0.01, "epochs": 100, "batch_size": 32}))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["config", "diff", str(c1), str(c2)])
+        assert result.exit_code == 0
+        assert "Config Diff" in result.output
+        assert "changed" in result.output or "lr" in result.output
+
+
+def test_config_show_cli():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.dump({"lr": 0.001, "model": {"backbone": "resnet", "layers": 50}}, f)
+        f.flush()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["config", "show", f.name])
+        assert result.exit_code == 0
+        assert "resnet" in result.output

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -1,0 +1,67 @@
+"""Tests for runs list and compare commands."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import mlflow
+from click.testing import CliRunner
+
+from olytrain.cli import cli
+
+
+def test_runs_list_no_runs():
+    """Test runs list with no runs in a temp MLflow DB."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        db_path = tmp_path / "mlflow.db"
+        tracking_uri = f"sqlite:///{db_path}"
+        artifact_root = tmp_path / "artifacts"
+        artifact_root.mkdir(parents=True, exist_ok=True)
+
+        with (
+            patch("olytrain.integrations.mlflow_setup.MLFLOW_DIR", tmp_path),
+            patch("olytrain.integrations.mlflow_setup.ARTIFACT_ROOT", artifact_root),
+            patch("olytrain.integrations.mlflow_setup.MLFLOW_TRACKING_URI", tracking_uri),
+        ):
+            mlflow.set_tracking_uri(tracking_uri)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["runs", "list"])
+            assert result.exit_code == 0
+            assert "No runs found" in result.output or "No experiments found" in result.output
+
+
+def test_runs_compare_with_real_runs():
+    """Test runs compare with two real MLflow runs."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        db_path = tmp_path / "mlflow.db"
+        tracking_uri = f"sqlite:///{db_path}"
+        artifact_root = tmp_path / "artifacts"
+        tmp_path.mkdir(exist_ok=True)
+        artifact_root.mkdir(exist_ok=True)
+
+        with (
+            patch("olytrain.integrations.mlflow_setup.MLFLOW_DIR", tmp_path),
+            patch("olytrain.integrations.mlflow_setup.ARTIFACT_ROOT", artifact_root),
+            patch("olytrain.integrations.mlflow_setup.MLFLOW_TRACKING_URI", tracking_uri),
+        ):
+            mlflow.set_tracking_uri(tracking_uri)
+            mlflow.set_experiment("test-compare")
+
+            with mlflow.start_run() as run1:
+                mlflow.log_param("lr", "0.001")
+                mlflow.log_metric("loss", 0.5)
+            run1_id = run1.info.run_id
+
+            with mlflow.start_run() as run2:
+                mlflow.log_param("lr", "0.01")
+                mlflow.log_metric("loss", 0.3)
+            run2_id = run2.info.run_id
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["runs", "compare", run1_id, run2_id])
+            assert result.exit_code == 0
+            assert "Parameters" in result.output
+            assert "Metrics" in result.output


### PR DESCRIPTION
## Summary
- `olytrain config diff` — side-by-side config comparison with change status markers
- `olytrain config show` — pretty-print flattened config via Rich tables
- `olytrain runs list` — tabular MLflow run listing with `--experiment`, `--sort`, `--limit`
- `olytrain runs compare` — param + metric comparison with colored deltas
- README.md with usage examples for all commands
- Fixed CLI tests for new required arguments

## Verification
- ruff: all passed
- mypy: 0 issues in 21 files
- pytest: **79/79 passed** in 5.86s
- `olytrain --help` shows complete command tree

Closes #8

## Test plan
- [x] Config diff shows changed/added/removed keys
- [x] Config show displays flattened key-value table
- [x] Runs list handles empty experiment gracefully
- [x] Runs compare shows params + metrics side-by-side with deltas
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)