### PR TITLE
Add onboarding docs and presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ olytrain eval vision checkpoint.h5 --config config.yaml --output results/
 - **Optional FiftyOne** — Dataset inspection is opt-in (`pip install olytrain[fiftyone]`)
 - **DDP-safe** — Callbacks only log from rank 0
 
+## Documentation
+
+- **[Getting Started Tutorial](docs/getting-started.md)** -- step-by-step guide from install to first tracked run
+- **[Onboarding Presentation](docs/presentation.md)** -- Marp slide deck for team walkthroughs (render with `npx @marp-team/marp-cli docs/presentation.md -o slides.html`)
+
 ## Project Structure
 
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,278 @@
+# Getting Started with olytrain
+
+This guide walks you through installing olytrain, tracking your first training run, and using the tools to manage experiments across olypro projects.
+
+## Prerequisites
+
+- Python 3.10+
+- An existing olypro-movenet or olypro-vision checkout (optional, for integration)
+
+## 1. Installation
+
+```bash
+# Clone the repo
+git clone https://github.com/Pyth14/olypro-training.git
+cd olypro-training
+
+# Create a virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
+
+# Install olytrain
+pip install -e .
+
+# For development (adds pytest, ruff, mypy):
+pip install -e ".[dev]"
+
+# For dataset inspection with FiftyOne:
+pip install -e ".[fiftyone]"
+```
+
+Verify it works:
+
+```bash
+olytrain --version
+# olytrain, version 0.1.0
+```
+
+## 2. Launch the Dashboard
+
+olytrain uses MLflow with a local SQLite database -- zero configuration needed.
+
+```bash
+olytrain dashboard
+```
+
+Open http://127.0.0.1:5000 in your browser. You'll see the MLflow UI with two pre-created experiments: **movenet** and **vision**.
+
+> **Tip:** Use `olytrain dashboard --port 8080` if port 5000 is taken.
+
+## 3. Add Tracking to Your Training Script
+
+### For olypro-movenet (Task-based training)
+
+Add these lines to your training script:
+
+```python
+# At the top of your script
+try:
+    from olytrain.integrations.mlflow_task import MLflowTaskCallback
+    callback = MLflowTaskCallback(
+        config=your_config_dict,      # Your training config
+        experiment_name="movenet",     # Shows up in MLflow UI
+        run_name="resnet50-lr0.001",   # Human-readable run name
+    )
+except ImportError:
+    callback = None  # olytrain not installed -- training still works
+```
+
+Then call the hooks at the right places in your training loop:
+
+```python
+# Before training starts
+if callback:
+    callback.on_train_start()
+
+# Inside your batch loop
+for step, batch in enumerate(dataloader):
+    loss = train_step(batch)
+    if callback:
+        callback.on_batch_end(step, {"train/loss": loss})
+
+# At the end of each epoch
+if callback:
+    callback.on_epoch_end(epoch, {
+        "val/acc": val_accuracy,
+        "val/loss": val_loss,
+    })
+
+# When saving a checkpoint
+if callback:
+    callback.on_checkpoint("checkpoints/best.pth", metric_value=val_accuracy)
+
+# After training finishes
+if callback:
+    callback.on_train_end()
+```
+
+**That's it.** Your training metrics, parameters, and checkpoints now appear in the MLflow dashboard.
+
+### For olypro-movenet (RTMPose training)
+
+Same pattern, different class:
+
+```python
+try:
+    from olytrain.integrations.mlflow_rtmpose import MLflowRTMPoseCallback
+    callback = MLflowRTMPoseCallback(config=config, run_name="rtmpose-s-coco")
+except ImportError:
+    callback = None
+```
+
+### For olypro-vision (TensorFlow)
+
+No code changes needed! olypro-vision already writes TensorBoard events. Just ingest them after training:
+
+```bash
+olytrain runs ingest /path/to/model_dir/train \
+    --experiment vision \
+    --run-name "efficientdet-d1-run3" \
+    --config /path/to/config.yaml
+```
+
+This reads the TensorBoard event files and logs all metrics (loss, AP, AP50, AP75) into MLflow.
+
+## 4. Browse and Compare Runs
+
+### In the browser
+
+```bash
+olytrain dashboard
+```
+
+Click an experiment, select multiple runs, and use MLflow's built-in comparison charts.
+
+### From the command line
+
+```bash
+# List recent runs
+olytrain runs list --experiment movenet
+
+# Sort by a metric
+olytrain runs list --experiment movenet --sort val/acc
+
+# Compare two specific runs
+olytrain runs compare <run_id_1> <run_id_2>
+```
+
+The compare command shows a side-by-side table of parameters and metrics with colored deltas.
+
+## 5. Inspect Your Dataset
+
+### Quick stats (no extra dependencies)
+
+```bash
+olytrain dataset stats /path/to/annotations.json
+```
+
+This parses the COCO JSON and prints:
+- Number of images and annotations
+- Class distribution table
+- Image size ranges
+
+### Visual inspection (requires FiftyOne)
+
+```bash
+pip install olytrain[fiftyone]
+
+olytrain dataset inspect annotations.json images/ --type keypoints
+olytrain dataset inspect annotations.json images/ --type detection
+```
+
+This launches the FiftyOne app in your browser where you can browse images, filter by class, and see annotation overlays.
+
+## 6. Manage Checkpoints
+
+### List all checkpoints
+
+```bash
+olytrain checkpoint list
+olytrain checkpoint list --project movenet
+```
+
+### Prune old checkpoints
+
+```bash
+# Preview what would be deleted (dry run)
+olytrain checkpoint prune movenet --keep 5
+
+# Actually delete
+olytrain checkpoint prune movenet --keep 5 --execute
+```
+
+### Sync to/from a remote machine
+
+```bash
+# Upload
+olytrain checkpoint sync ./checkpoints/ gpu-server /data/checkpoints/
+
+# Download
+olytrain checkpoint sync ./local/ gpu-server /data/checkpoints/ --download
+```
+
+## 7. Compare Training Configs
+
+When experimenting with different hyperparameters:
+
+```bash
+# View a config
+olytrain config show config.yaml
+
+# Diff two configs
+olytrain config diff baseline.yaml experiment.yaml
+```
+
+The diff highlights added, removed, and changed parameters in a color-coded table.
+
+## 8. DDP / Multi-GPU Training
+
+The callbacks are DDP-safe by default. Only rank 0 logs to MLflow -- other ranks are automatic no-ops. No extra configuration needed.
+
+```bash
+# This just works
+torchrun --nproc_per_node=4 train.py
+```
+
+## Common Workflows
+
+### "I just finished a training run, now what?"
+
+1. `olytrain dashboard` -- check your run appeared
+2. `olytrain runs list --experiment movenet --sort val/acc` -- see where it ranks
+3. `olytrain runs compare <old_best> <new_run>` -- compare against previous best
+4. `olytrain checkpoint prune movenet --keep 5 --execute` -- clean up old checkpoints
+
+### "I want to try a new config"
+
+1. `olytrain config diff old_config.yaml new_config.yaml` -- review changes
+2. Run training with the callback
+3. `olytrain runs compare` -- see if it helped
+
+### "I need to share results with the team"
+
+1. `olytrain dashboard --host 0.0.0.0` -- expose MLflow on the network
+2. Share the URL -- teammates can browse all experiments and runs
+
+## Troubleshooting
+
+**"olytrain: command not found"**
+Make sure you activated the venv: `source .venv/bin/activate`
+
+**"No experiments found"**
+Run `olytrain dashboard` once to initialize the MLflow database.
+
+**Metrics not appearing in MLflow**
+- Check that `on_train_start()` was called before logging metrics
+- Check that `on_train_end()` was called to finalize the run
+- For TF-Vision, make sure you're pointing at the right TensorBoard event directory
+
+**FiftyOne won't launch**
+Install with: `pip install olytrain[fiftyone]`
+
+## Quick Reference
+
+| Command | What it does |
+|---------|-------------|
+| `olytrain dashboard` | Launch MLflow UI |
+| `olytrain runs list` | List training runs |
+| `olytrain runs compare A B` | Compare two runs |
+| `olytrain runs ingest DIR` | Import TensorBoard events |
+| `olytrain dataset stats FILE` | Dataset statistics |
+| `olytrain dataset inspect FILE DIR` | Visual dataset browser |
+| `olytrain checkpoint list` | List checkpoints |
+| `olytrain checkpoint prune PROJECT` | Clean up old checkpoints |
+| `olytrain checkpoint sync` | Upload/download checkpoints |
+| `olytrain config show FILE` | Pretty-print config |
+| `olytrain config diff A B` | Compare two configs |
+| `olytrain eval movenet CKPT` | Evaluate pose model |
+| `olytrain eval vision CKPT` | Evaluate detection model |

--- a/docs/presentation.md
+++ b/docs/presentation.md
@@ -1,0 +1,431 @@
+---
+marp: true
+theme: default
+paginate: true
+header: "**olytrain** -- Training Infrastructure for Olypro"
+footer: "Pyth14 / olypro-training"
+style: |
+  section {
+    font-size: 24px;
+  }
+  h1 {
+    color: #2563eb;
+  }
+  h2 {
+    color: #1e40af;
+  }
+  code {
+    background: #f1f5f9;
+    border-radius: 4px;
+    padding: 2px 6px;
+  }
+  table {
+    font-size: 20px;
+  }
+  .columns {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+---
+
+# olytrain
+
+### Unified Training Infrastructure for Olypro Projects
+
+**What:** A shared Python package for experiment tracking, dataset inspection, checkpoint management, and evaluation.
+
+**Why:** Both olypro-movenet and olypro-vision had ad-hoc training scripts with no unified way to track experiments, compare runs, or manage checkpoints.
+
+**How:** MLflow + FiftyOne + custom tooling, wrapped in a simple CLI.
+
+---
+
+# The Problem
+
+### Before olytrain
+
+- Training metrics logged to TensorBoard or print statements
+- No way to compare runs across experiments
+- Checkpoints accumulate with no cleanup strategy
+- Dataset issues discovered late in training
+- Config changes tracked in git commits (if at all)
+- Each project had its own ad-hoc tooling
+
+### The cost
+
+Wasted GPU hours, lost experiments, "which config produced that result?"
+
+---
+
+# The Solution
+
+### olytrain gives you
+
+| Capability | Tool | Command |
+|-----------|------|---------|
+| Experiment tracking | MLflow | `olytrain dashboard` |
+| Run comparison | MLflow + Rich | `olytrain runs compare` |
+| Dataset inspection | FiftyOne | `olytrain dataset inspect` |
+| Checkpoint management | Custom | `olytrain checkpoint list/prune` |
+| Config diffing | Custom | `olytrain config diff` |
+| Eval reports | Matplotlib + Rich | `olytrain eval` |
+
+**One `pip install`, zero infrastructure.**
+
+---
+
+# Architecture
+
+```
+olypro-movenet                    olypro-vision
+     |                                  |
+     | MLflowTaskCallback               | TensorBoard events
+     | (5 lines of code)                | (no code changes)
+     |                                  |
+     v                                  v
+  +-------------------------------------------------+
+  |                   olytrain                       |
+  |                                                  |
+  |  MLflow (SQLite)  |  FiftyOne  |  Checkpoints   |
+  |  - params         |  - browse  |  - discover     |
+  |  - metrics        |  - filter  |  - prune        |
+  |  - artifacts      |  - stats   |  - sync         |
+  +-------------------------------------------------+
+                        |
+                   CLI + Web UI
+```
+
+---
+
+# Design Principles
+
+### 1. Composition over modification
+
+Callbacks are standalone objects. Training scripts get ~5 lines added, guarded by `try/except ImportError`. Both projects work fine without olytrain installed.
+
+### 2. Zero-setup infrastructure
+
+MLflow backend is SQLite. No server to deploy, no database to manage. Just `pip install` and go.
+
+### 3. Optional dependencies
+
+FiftyOne is heavy. It's optional: `pip install olytrain[fiftyone]`. Base package stays lightweight for cloud instances.
+
+### 4. DDP-safe
+
+Callbacks check `LOCAL_RANK`. Only rank 0 writes to MLflow. No duplicate metrics, no race conditions.
+
+---
+
+# Getting Started (2 minutes)
+
+### Install
+
+```bash
+pip install -e /path/to/olypro-training
+```
+
+### Launch the dashboard
+
+```bash
+olytrain dashboard
+```
+
+### Open http://localhost:5000
+
+You'll see two experiments pre-created: **movenet** and **vision**.
+
+That's it. You're ready to start tracking.
+
+---
+
+# Adding Tracking to movenet
+
+### Add to your training script
+
+```python
+try:
+    from olytrain.integrations.mlflow_task import MLflowTaskCallback
+    cb = MLflowTaskCallback(config=config, run_name="my-experiment")
+except ImportError:
+    cb = None
+```
+
+### Call hooks in your training loop
+
+```python
+if cb: cb.on_train_start()
+
+for epoch in range(num_epochs):
+    for step, batch in enumerate(loader):
+        loss = train_step(batch)
+        if cb: cb.on_batch_end(step, {"train/loss": loss})
+
+    val_acc = validate()
+    if cb: cb.on_epoch_end(epoch, {"val/acc": val_acc})
+
+if cb: cb.on_train_end()
+```
+
+---
+
+# Adding Tracking to vision
+
+### No code changes needed!
+
+olypro-vision already writes TensorBoard events. Just ingest them:
+
+```bash
+olytrain runs ingest /path/to/model_dir/train \
+    --experiment vision \
+    --run-name "efficientdet-d1" \
+    --config config.yaml
+```
+
+### What gets logged
+
+- `total_loss`, `cls_loss`, `box_loss`, `regularization_loss`
+- `AP`, `AP50`, `AP75`
+- Config parameters (from YAML)
+
+### Live monitoring
+
+```bash
+olytrain runs ingest /path/to/events --watch
+```
+
+Polls every 30 seconds during training.
+
+---
+
+# The MLflow Dashboard
+
+### What you see
+
+- **Experiments list** -- movenet, vision, grouped by project
+- **Runs table** -- all runs with status, timestamps, metrics
+- **Run detail** -- parameters, metric charts, artifacts
+- **Comparison view** -- select multiple runs, overlay metric curves
+
+### Key features
+
+- **Search & filter** -- `metrics.val_acc > 0.8 AND params.backbone = "resnet50"`
+- **Metric charts** -- interactive, zoomable, per-batch resolution
+- **Artifact storage** -- checkpoints, configs, eval images
+
+---
+
+# Comparing Runs
+
+### From the CLI
+
+```bash
+$ olytrain runs compare <run_1> <run_2>
+
+              Parameters
++------------+-----------+-----------+-------+
+| Param      | Run A     | Run B     | Match |
++------------+-----------+-----------+-------+
+| backbone   | resnet50  | mobilenet | !=    |
+| lr         | 0.001     | 0.01      | !=    |
+| batch_size | 32        | 64        | !=    |
++------------+-----------+-----------+-------+
+
+              Metrics
++------------+---------+---------+---------+
+| Metric     | Run A   | Run B   | Delta   |
++------------+---------+---------+---------+
+| val/acc    | 0.8200  | 0.8500  | +0.0300 |
+| val/loss   | 0.4200  | 0.3800  | -0.0400 |
++------------+---------+---------+---------+
+```
+
+---
+
+# Dataset Inspection
+
+### Quick stats (no extra deps)
+
+```bash
+$ olytrain dataset stats annotations.json
+
+Images: 5000, Annotations: 23847
++----------+-------+
+| Class    | Count |
++----------+-------+
+| person   | 12450 |
+| dog      |  3200 |
+| cat      |  2890 |
++----------+-------+
+Width: 640-1920 (mean 1056)
+Height: 480-1080 (mean 672)
+```
+
+### Visual browser (FiftyOne)
+
+```bash
+olytrain dataset inspect annotations.json images/ --type keypoints
+```
+
+Opens a web app where you can browse images, see keypoint overlays, filter by class, and spot annotation errors.
+
+---
+
+# Checkpoint Management
+
+### The problem
+
+After 50 training runs, you have 200+ checkpoint files consuming hundreds of GB.
+
+### The solution
+
+```bash
+# See what you have
+$ olytrain checkpoint list --project movenet
+
++----------+---------------------------+--------+------------------+
+| Project  | Path                      | Size   | Modified         |
++----------+---------------------------+--------+------------------+
+| movenet  | checkpoints/epoch_50.pth  | 245 MB | 2026-03-06 14:30 |
+| movenet  | checkpoints/epoch_49.pth  | 245 MB | 2026-03-06 12:15 |
+| ...      | ...                       | ...    | ...              |
++----------+---------------------------+--------+------------------+
+
+# Keep the 5 most recent, delete the rest
+$ olytrain checkpoint prune movenet --keep 5 --execute
+
+# Sync best checkpoint to GPU server
+$ olytrain checkpoint sync best.pth gpu-server /data/models/
+```
+
+---
+
+# Config Diffing
+
+### Before a new experiment
+
+```bash
+$ olytrain config diff baseline.yaml experiment.yaml
+
++--------------------+----------+----------+-----------+
+| Key                | baseline | new      | Status    |
++--------------------+----------+----------+-----------+
+| model.backbone     | resnet50 | mobilev2 | ~ changed |
+| training.lr        | 0.001    | 0.01     | ~ changed |
+| training.scheduler | -        | cosine   | + added   |
+| augment.cutout     | true     | -        | - removed |
++--------------------+----------+----------+-----------+
+```
+
+Instantly see what changed before committing GPU time.
+
+---
+
+# Evaluation Reports
+
+### Pose estimation
+
+```bash
+olytrain eval movenet checkpoint.pth
+```
+
+Generates:
+- Per-keypoint accuracy heatmap (color-coded nose-to-ankle)
+- Prediction overlay images (green = GT, red = predicted)
+- Rich table with Good/Fair/Poor status per keypoint
+
+### Object detection
+
+```bash
+olytrain eval vision checkpoint.h5
+```
+
+Generates:
+- Per-class AP bar chart
+- Bounding box overlay images
+- Detection report with mAP summary
+
+---
+
+# Typical Workflow
+
+```
+1. olytrain config diff old.yaml new.yaml    # Review config changes
+                    |
+2. python train.py                            # Train with callback
+                    |
+3. olytrain dashboard                         # Check metrics in browser
+                    |
+4. olytrain runs compare old_best new_run     # Did it improve?
+                    |
+    +--- YES -------+------- NO ---+
+    |                              |
+5a. olytrain checkpoint            5b. Adjust config,
+    prune --keep 5 --execute           go to step 1
+    |
+6. olytrain checkpoint sync
+   best.pth gpu-server /models/
+```
+
+---
+
+# What Changes in Your Code
+
+### olypro-movenet: ~5 lines per training script
+
+```python
+# Add at top (guarded import)
+try:
+    from olytrain.integrations.mlflow_task import MLflowTaskCallback
+    cb = MLflowTaskCallback(config=cfg, run_name="exp-name")
+except ImportError:
+    cb = None
+
+# Add at training hooks (already exist in task.py)
+if cb: cb.on_train_start()
+if cb: cb.on_batch_end(step, metrics)
+if cb: cb.on_epoch_end(epoch, metrics)
+if cb: cb.on_train_end()
+```
+
+### olypro-vision: 0 lines
+
+TensorBoard events are parsed externally. Run `olytrain runs ingest` after training.
+
+---
+
+# FAQ
+
+**Q: Do I have to use olytrain?**
+A: No. It's optional. Training works without it. The `try/except ImportError` guard means your scripts don't break if olytrain isn't installed.
+
+**Q: Does it slow down training?**
+A: Negligible. MLflow logging is ~1ms per call. Callbacks are no-ops on non-rank-0 GPUs.
+
+**Q: Where is data stored?**
+A: `~/.olypro-mlflow/mlflow.db` (SQLite) and `~/.olypro-mlflow/artifacts/`. Everything is local.
+
+**Q: Can the team share a dashboard?**
+A: Yes. Run `olytrain dashboard --host 0.0.0.0` on a shared machine. Or deploy MLflow server for production use.
+
+**Q: What about Weights & Biases / Neptune / etc?**
+A: MLflow is open-source, self-hosted, and free. No accounts, no vendor lock-in, no data leaving your network.
+
+---
+
+# Next Steps
+
+1. **Install olytrain** in your environment
+2. **Run `olytrain dashboard`** to see the UI
+3. **Add the callback** to your next training run
+4. **Check your dataset** with `olytrain dataset stats`
+5. **Clean up checkpoints** with `olytrain checkpoint prune`
+
+### Resources
+
+- Repo: `github.com/Pyth14/olypro-training`
+- Tutorial: `docs/getting-started.md`
+- CLI help: `olytrain --help`
+
+### Questions?


### PR DESCRIPTION
## Summary
- `docs/getting-started.md` — comprehensive tutorial covering install, callbacks, TF-Vision ingestion, dataset inspection, checkpoint management, config diffing, eval reports, DDP, common workflows, and troubleshooting
- `docs/presentation.md` — 17-slide Marp deck for team onboarding sessions
- README updated with links to both

## How to use the presentation

```bash
# Render to HTML
npx @marp-team/marp-cli docs/presentation.md -o slides.html

# Render to PDF
npx @marp-team/marp-cli docs/presentation.md -o slides.pdf

# Live preview
npx @marp-team/marp-cli -s docs/
```

Closes #15

## Test plan
- [x] All existing tests still pass (79/79)
- [x] Markdown renders correctly
- [x] All code examples are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)