### PR TITLE
Add init/status commands, color-coded metrics, fix checkpoint paths

### DIFF
--- a/src/olytrain/checkpoint/manager.py
+++ b/src/olytrain/checkpoint/manager.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
-from olytrain.config import OLYPRO_MOVENET_DIR, OLYPRO_VISION_DIR
+from olytrain.config import CHECKPOINT_DIRS
 
 CHECKPOINT_EXTENSIONS = {".pth", ".pt", ".ckpt", ".index", ".h5", ".keras", ".safetensors"}
 
@@ -35,10 +35,7 @@ class CheckpointManager:
     """Discover, list, and prune checkpoints across projects."""
 
     def __init__(self, project_dirs: dict[str, Path] | None = None) -> None:
-        self.project_dirs = project_dirs or {
-            "movenet": OLYPRO_MOVENET_DIR,
-            "vision": OLYPRO_VISION_DIR,
-        }
+        self.project_dirs = project_dirs or CHECKPOINT_DIRS
 
     def discover(self, project_dir: Path, project_name: str = "unknown") -> list[CheckpointInfo]:
         """Scan a directory recursively for checkpoint files."""

--- a/src/olytrain/cli/__init__.py
+++ b/src/olytrain/cli/__init__.py
@@ -7,7 +7,9 @@ from olytrain.cli.config import config
 from olytrain.cli.dashboard import dashboard
 from olytrain.cli.dataset import dataset
 from olytrain.cli.eval import eval_cmd
+from olytrain.cli.init import init
 from olytrain.cli.runs import runs
+from olytrain.cli.status import status
 
 
 @click.group()
@@ -22,3 +24,5 @@ cli.add_command(dataset)
 cli.add_command(checkpoint)
 cli.add_command(eval_cmd)
 cli.add_command(config)
+cli.add_command(init)
+cli.add_command(status)

--- a/src/olytrain/cli/init.py
+++ b/src/olytrain/cli/init.py
@@ -1,0 +1,56 @@
+"""Init command -- detect projects, verify paths, set up MLflow."""
+
+from __future__ import annotations
+
+import click
+from rich.console import Console
+
+from olytrain.config import (
+    MLFLOW_TRACKING_URI,
+    OLYPRO_MOVENET_DIR,
+    OLYPRO_VISION_DIR,
+)
+
+
+def _check(console: Console, label: str, exists: bool) -> None:
+    """Print a checkmark or cross for a path check."""
+    if exists:
+        console.print(f"  [green]v[/green] {label}")
+    else:
+        console.print(f"  [red]x[/red] {label}")
+
+
+@click.command()
+def init() -> None:
+    """Initialize olytrain -- detect projects, verify paths, set up MLflow."""
+    from olytrain.integrations.mlflow_setup import ensure_mlflow
+
+    console = Console()
+
+    console.print("[bold]Setting up MLflow...[/bold]")
+    ensure_mlflow()
+    console.print(f"  [green]v[/green] MLflow DB ready at {MLFLOW_TRACKING_URI}")
+
+    console.print()
+    console.print("[bold]Checking olypro-movenet...[/bold]")
+    if OLYPRO_MOVENET_DIR.exists():
+        console.print(f"  [green]v[/green] Found {OLYPRO_MOVENET_DIR}")
+        _check(console, "data/ directory", (OLYPRO_MOVENET_DIR / "data").is_dir())
+        _check(console, "output/ directory", (OLYPRO_MOVENET_DIR / "output").is_dir())
+        _check(console, "config.py", (OLYPRO_MOVENET_DIR / "config.py").is_file())
+    else:
+        console.print(f"  [red]x[/red] Not found: {OLYPRO_MOVENET_DIR}")
+
+    console.print()
+    console.print("[bold]Checking olypro-vision...[/bold]")
+    if OLYPRO_VISION_DIR.exists():
+        console.print(f"  [green]v[/green] Found {OLYPRO_VISION_DIR}")
+        _check(console, "annotations/ directory", (OLYPRO_VISION_DIR / "annotations").is_dir())
+        _check(console, "configs/ directory", (OLYPRO_VISION_DIR / "configs").is_dir())
+        _check(console, "models/ directory", (OLYPRO_VISION_DIR / "models").is_dir())
+    else:
+        console.print(f"  [red]x[/red] Not found: {OLYPRO_VISION_DIR}")
+
+    console.print()
+    console.print(f"[bold]MLflow tracking URI:[/bold] {MLFLOW_TRACKING_URI}")
+    console.print("Run [cyan]olytrain dashboard[/cyan] to start the UI")

--- a/src/olytrain/cli/runs.py
+++ b/src/olytrain/cli/runs.py
@@ -7,6 +7,31 @@ from rich.console import Console
 from rich.table import Table
 
 
+def _color_metric(name: str, value: float) -> str:
+    """Color a metric value based on known thresholds."""
+    if "loss" in name:
+        # Lower is better for loss
+        if value < 0.3:
+            return f"[green]{value:.4f}[/green]"
+        if value < 0.7:
+            return f"[yellow]{value:.4f}[/yellow]"
+        return f"[red]{value:.4f}[/red]"
+    if "acc" in name or "pck" in name:
+        # Higher is better for accuracy
+        if value >= 0.8:
+            return f"[green]{value:.4f}[/green]"
+        if value >= 0.5:
+            return f"[yellow]{value:.4f}[/yellow]"
+        return f"[red]{value:.4f}[/red]"
+    if name.startswith("AP") or name == "mAP":
+        if value >= 0.5:
+            return f"[green]{value:.4f}[/green]"
+        if value >= 0.3:
+            return f"[yellow]{value:.4f}[/yellow]"
+        return f"[red]{value:.4f}[/red]"
+    return f"{value:.4f}"
+
+
 @click.group()
 def runs() -> None:
     """Manage and inspect training runs."""
@@ -74,7 +99,11 @@ def list_runs(experiment: str | None, sort_by: str | None, limit: int) -> None:
         ]
         for col in metric_cols:
             val = row.get(col)
-            values.append(f"{val:.4f}" if val is not None and val == val else "")
+            if val is not None and val == val:
+                metric_name = col.replace("metrics.", "")
+                values.append(_color_metric(metric_name, val))
+            else:
+                values.append("")
         table.add_row(*values)
 
     console.print(table)

--- a/src/olytrain/cli/status.py
+++ b/src/olytrain/cli/status.py
@@ -1,0 +1,103 @@
+"""Status command -- show overview of experiments, runs, and checkpoints."""
+
+from __future__ import annotations
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+
+@click.command()
+def status() -> None:
+    """Show overview of experiments, runs, and checkpoints."""
+    import mlflow
+
+    from olytrain.checkpoint.manager import CheckpointManager
+    from olytrain.config import OLYPRO_VISION_DIR
+    from olytrain.integrations.mlflow_setup import ensure_mlflow
+
+    console = Console()
+
+    # --- MLflow Runs ---
+    console.print("[bold]Recent MLflow Runs[/bold]")
+    ensure_mlflow()
+
+    experiments = [e for e in mlflow.search_experiments() if e.name != "Default"]
+    if not experiments:
+        console.print("  No experiments found.")
+    else:
+        table = Table()
+        table.add_column("Run Name")
+        table.add_column("Experiment")
+        table.add_column("Status")
+        table.add_column("Key Metric", justify="right")
+
+        any_runs = False
+        for exp in experiments:
+            runs_df = mlflow.search_runs(
+                experiment_ids=[exp.experiment_id],
+                order_by=["start_time DESC"],
+                max_results=5,
+                output_format="pandas",
+            )
+            if runs_df.empty:  # type: ignore[union-attr]
+                continue
+            any_runs = True
+            metric_cols = [
+                c for c in runs_df.columns if c.startswith("metrics.")  # type: ignore[union-attr]
+            ][:1]
+            for _, row in runs_df.iterrows():  # type: ignore[union-attr]
+                run_name = row.get("tags.mlflow.runName", "")
+                run_status = row.get("status", "")
+                key_metric = ""
+                if metric_cols:
+                    val = row.get(metric_cols[0])
+                    if val is not None and val == val:
+                        key_metric = f"{metric_cols[0].replace('metrics.', '')}: {val:.4f}"
+                table.add_row(str(run_name), exp.name, str(run_status), key_metric)
+
+        if any_runs:
+            console.print(table)
+        else:
+            console.print("  No runs found.")
+
+    # --- Checkpoints ---
+    console.print()
+    console.print("[bold]Checkpoint Disk Usage[/bold]")
+    mgr = CheckpointManager()
+    any_checkpoints = False
+    for project_name, project_dir in mgr.project_dirs.items():
+        ckpts = mgr.discover(project_dir, project_name)
+        if ckpts:
+            any_checkpoints = True
+            total_mb = sum(c.size_mb for c in ckpts)
+            console.print(f"  {project_name}: {len(ckpts)} checkpoint(s), {total_mb:.1f} MB")
+        else:
+            console.print(f"  {project_name}: no checkpoints found")
+    if not any_checkpoints:
+        console.print("  No checkpoints found across projects.")
+
+    # --- Dataset Info ---
+    console.print()
+    console.print("[bold]Dataset Info[/bold]")
+    annotation_paths = [
+        OLYPRO_VISION_DIR / "annotations" / "instances_train.json",
+        OLYPRO_VISION_DIR / "annotations" / "instances_val.json",
+    ]
+    any_datasets = False
+    for ann_path in annotation_paths:
+        if ann_path.is_file():
+            any_datasets = True
+            try:
+                from olytrain.integrations.fiftyone_loader import dataset_stats
+
+                s = dataset_stats(str(ann_path))
+                num_classes = len(s.get("class_distribution", {}))
+                console.print(
+                    f"  {ann_path.name}: {s['num_images']} images, "
+                    f"{num_classes} classes"
+                )
+            except Exception as exc:
+                console.print(f"  {ann_path.name}: error reading - {exc}")
+    if not any_datasets:
+        console.print("  No annotation files found.")

--- a/src/olytrain/config.py
+++ b/src/olytrain/config.py
@@ -11,3 +11,9 @@ DEFAULT_EXPERIMENTS = ("movenet", "vision")
 
 OLYPRO_MOVENET_DIR = Path.home() / "src" / "olypro-movenet"
 OLYPRO_VISION_DIR = Path.home() / "src" / "olypro-vision"
+
+# Project-specific checkpoint directories
+CHECKPOINT_DIRS = {
+    "movenet": OLYPRO_MOVENET_DIR / "output",
+    "vision": OLYPRO_VISION_DIR / "models",
+}

--- a/tests/test_checkpoint_manager.py
+++ b/tests/test_checkpoint_manager.py
@@ -162,24 +162,24 @@ class TestCheckpointPrune:
 
 
 class TestCheckpointCLI:
-    def test_list_command_no_checkpoints(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_list_command_no_checkpoints(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setattr(
-            "olytrain.checkpoint.manager.OLYPRO_MOVENET_DIR", tmp_path / "empty_mv"
-        )
-        monkeypatch.setattr(
-            "olytrain.checkpoint.manager.OLYPRO_VISION_DIR", tmp_path / "empty_vis"
+            "olytrain.checkpoint.manager.CHECKPOINT_DIRS",
+            {"movenet": tmp_path / "empty_mv", "vision": tmp_path / "empty_vis"},
         )
         runner = CliRunner()
         result = runner.invoke(cli, ["checkpoint", "list"])
         assert result.exit_code == 0
         assert "No checkpoints found" in result.output
 
-    def test_list_command_with_checkpoints(self, ckpt_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_list_command_with_checkpoints(
+        self, ckpt_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setattr(
-            "olytrain.checkpoint.manager.OLYPRO_MOVENET_DIR", ckpt_dir
-        )
-        monkeypatch.setattr(
-            "olytrain.checkpoint.manager.OLYPRO_VISION_DIR", ckpt_dir.parent / "empty"
+            "olytrain.checkpoint.manager.CHECKPOINT_DIRS",
+            {"movenet": ckpt_dir, "vision": ckpt_dir.parent / "empty"},
         )
         runner = CliRunner()
         result = runner.invoke(cli, ["checkpoint", "list"], catch_exceptions=False)

--- a/tests/test_init_status.py
+++ b/tests/test_init_status.py
@@ -1,0 +1,164 @@
+"""Tests for init, status commands, color-coded metrics, and checkpoint path defaults."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from olytrain.checkpoint.manager import CheckpointManager
+from olytrain.cli import cli
+from olytrain.cli.runs import _color_metric
+from olytrain.config import CHECKPOINT_DIRS
+
+# --- init command tests ---
+
+
+def test_init_runs_without_error():
+    """olytrain init should complete without crashing, even when projects are absent."""
+    runner = CliRunner()
+    with patch("olytrain.cli.init.OLYPRO_MOVENET_DIR", Path("/nonexistent/movenet")), patch(
+        "olytrain.cli.init.OLYPRO_VISION_DIR", Path("/nonexistent/vision")
+    ):
+        result = runner.invoke(cli, ["init"])
+    assert result.exit_code == 0
+    assert "MLflow DB ready" in result.output
+    assert "Not found" in result.output
+
+
+def test_init_detects_existing_project(tmp_path: Path):
+    """init should detect existing project dirs and sub-paths."""
+    movenet = tmp_path / "olypro-movenet"
+    movenet.mkdir()
+    (movenet / "data").mkdir()
+    (movenet / "output").mkdir()
+    (movenet / "config.py").write_text("# config")
+
+    runner = CliRunner()
+    with patch("olytrain.cli.init.OLYPRO_MOVENET_DIR", movenet), patch(
+        "olytrain.cli.init.OLYPRO_VISION_DIR", Path("/nonexistent/vision")
+    ):
+        result = runner.invoke(cli, ["init"])
+    assert result.exit_code == 0
+    assert "data/ directory" in result.output
+    assert "output/ directory" in result.output
+    assert "config.py" in result.output
+
+
+def test_init_help():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["init", "--help"])
+    assert result.exit_code == 0
+    assert "Initialize olytrain" in result.output
+
+
+# --- status command tests ---
+
+
+def test_status_runs_without_error():
+    """olytrain status should complete without crashing with empty MLflow DB."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["status"])
+    assert result.exit_code == 0
+    assert "Recent MLflow Runs" in result.output
+    assert "Checkpoint Disk Usage" in result.output
+    assert "Dataset Info" in result.output
+
+
+def test_status_help():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["status", "--help"])
+    assert result.exit_code == 0
+    assert "Show overview" in result.output
+
+
+# --- _color_metric tests ---
+
+
+def test_color_metric_loss_green():
+    result = _color_metric("val/loss", 0.1)
+    assert "[green]" in result
+    assert "0.1000" in result
+
+
+def test_color_metric_loss_yellow():
+    result = _color_metric("train_loss", 0.5)
+    assert "[yellow]" in result
+    assert "0.5000" in result
+
+
+def test_color_metric_loss_red():
+    result = _color_metric("loss", 0.9)
+    assert "[red]" in result
+    assert "0.9000" in result
+
+
+def test_color_metric_accuracy_green():
+    result = _color_metric("val/acc", 0.95)
+    assert "[green]" in result
+
+
+def test_color_metric_accuracy_yellow():
+    result = _color_metric("pck@0.5", 0.6)
+    assert "[yellow]" in result
+
+
+def test_color_metric_accuracy_red():
+    result = _color_metric("acc", 0.2)
+    assert "[red]" in result
+
+
+def test_color_metric_ap_green():
+    result = _color_metric("AP50", 0.7)
+    assert "[green]" in result
+
+
+def test_color_metric_ap_yellow():
+    result = _color_metric("AP75", 0.35)
+    assert "[yellow]" in result
+
+
+def test_color_metric_ap_red():
+    result = _color_metric("AP", 0.1)
+    assert "[red]" in result
+
+
+def test_color_metric_map():
+    result = _color_metric("mAP", 0.6)
+    assert "[green]" in result
+
+
+def test_color_metric_unknown():
+    result = _color_metric("lr", 0.001)
+    assert "0.0010" in result
+    assert "[green]" not in result
+    assert "[red]" not in result
+
+
+# --- checkpoint manager default paths ---
+
+
+def test_checkpoint_manager_uses_checkpoint_dirs():
+    """Default CheckpointManager should use CHECKPOINT_DIRS (subdirs, not project roots)."""
+    mgr = CheckpointManager()
+    assert mgr.project_dirs == CHECKPOINT_DIRS
+    assert "output" in str(mgr.project_dirs["movenet"])
+    assert "models" in str(mgr.project_dirs["vision"])
+
+
+def test_checkpoint_manager_custom_dirs(tmp_path: Path):
+    """CheckpointManager should accept custom dirs override."""
+    custom = {"test": tmp_path}
+    mgr = CheckpointManager(project_dirs=custom)
+    assert mgr.project_dirs == custom
+
+
+# --- CLI help includes new commands ---
+
+
+def test_all_subcommands_visible_in_help():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    for cmd in ["dashboard", "runs", "dataset", "checkpoint", "eval", "config", "init", "status"]:
+        assert cmd in result.output, f"'{cmd}' not found in CLI help"

--- a/tests/test_mlflow_callbacks.py
+++ b/tests/test_mlflow_callbacks.py
@@ -7,8 +7,8 @@ from unittest.mock import patch
 
 import mlflow
 
-from olytrain.integrations.mlflow_task import MLflowTaskCallback, flatten_config
 from olytrain.integrations.mlflow_rtmpose import MLflowRTMPoseCallback
+from olytrain.integrations.mlflow_task import MLflowTaskCallback, flatten_config
 
 
 class TestFlattenConfig:


### PR DESCRIPTION
## Summary

- Add `olytrain init` command that detects olypro-movenet/olypro-vision on disk, verifies subdirectory structure (data/, output/, config.py, annotations/, configs/, models/), creates MLflow DB + experiments, and prints a Rich-formatted summary
- Add `olytrain status` command showing recent MLflow runs (last 5 per experiment), checkpoint disk usage per project, and dataset annotation counts -- handles empty/missing state gracefully
- Add `_color_metric()` helper to `runs list` that applies green/yellow/red Rich markup based on metric type and thresholds (loss, acc/pck, AP/mAP)
- Add `CHECKPOINT_DIRS` to config.py pointing to `output/` (movenet) and `models/` (vision) subdirectories
- Update `CheckpointManager` default to use `CHECKPOINT_DIRS` instead of project root dirs
- Fix pre-existing lint issues in test_checkpoint_manager.py (line length) and test_mlflow_callbacks.py (import order)

Closes #17

## Test plan

- [x] `olytrain init` runs without error with mocked absent projects
- [x] `olytrain init` detects existing project directories and sub-paths
- [x] `olytrain status` runs without error with empty MLflow DB
- [x] `_color_metric` returns correct Rich markup for loss (green/yellow/red thresholds)
- [x] `_color_metric` returns correct Rich markup for acc/pck metrics
- [x] `_color_metric` returns correct Rich markup for AP/mAP metrics
- [x] `_color_metric` returns plain format for unknown metrics
- [x] `CheckpointManager` defaults to `CHECKPOINT_DIRS` (output/ and models/ subdirs)
- [x] All 98 tests pass, ruff clean, mypy clean

Generated with [Claude Code](https://claude.com/claude-code)